### PR TITLE
fix: changed product price type to integer

### DIFF
--- a/server/db/models/products.js
+++ b/server/db/models/products.js
@@ -25,7 +25,7 @@ const Product = db.define('product', {
   },
 
   price: {
-    type: Sequelize.DECIMAL(10, 2),
+    type: Sequelize.INTEGER,
     validate: {
       isDecimal: true,
       min: 0.0
@@ -43,6 +43,10 @@ const Product = db.define('product', {
     type: Sequelize.TEXT,
     defaultValue: 'Uncategorized'
   }
+})
+
+Product.beforeCreate(product => {
+  product.price = product.price * 100
 })
 
 module.exports = Product


### PR DESCRIPTION
Quick fix, changing product model price to integer. 
-A beforeHook is created so that users have a friendly way to input dollar with decimal values, but will be converted before entering database.
-When displaying price values on the front end, values must be calculated by dividing by 100.